### PR TITLE
EDGEDCB-22: Add TLS configuration and updating dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ Institutional users should be granted the following permissions in order to use 
 
 ***System properties***
 
-| Property             | Default                                   | Description                                                         |
-|----------------------|-------------------------------------------|---------------------------------------------------------------------|
-| `server.port`        | `8081`                                    | Server port to listen on                                            |
-| `okapi_url`          | `http://okapi:9130`	                      | Okapi (URL)                                                         |
-| `secure_store`       | `Ephemeral`                               | Type of secure store to use.  Valid: `Ephemeral`, `AwsSsm`, `Vault` |
-| `secure_store_props` | `src/main/resources/ephemeral.properties` | Path to a properties file specifying secure store configuration     |
+| Property                | Default                                   | Description                                                         |
+|-------------------------|-------------------------------------------|---------------------------------------------------------------------|
+| `server.port`           | `8081`                                    | Server port to listen on                                            |
+| `folio.client.okapiUrl` | `http://okapi:9130`                      | Okapi (URL)                                                         |
+| `secure_store`          | `Ephemeral`                               | Type of secure store to use.  Valid: `Ephemeral`, `AwsSsm`, `Vault` |
+| `secure_store_props`    | `src/main/resources/ephemeral.properties` | Path to a properties file specifying secure store configuration     |
 
 ### Ephemeral properties for Karate runs.
 For Karate Tests to run successfully the `ephemeral.properties` values would be as mentioned below -

--- a/README.md
+++ b/README.md
@@ -66,6 +66,95 @@ documentation [Spring Boot Externalized Configuration](https://docs.spring.io/sp
 1. Using the environment variable `SPRING_APPLICATION_JSON` (example: `SPRING_APPLICATION_JSON='{"foo":{"bar":"spam"}}'`)
 2. Using the system variables within the `JAVA_OPTIONS` (example: `JAVA_OPTIONS=-Xmx400m -Dserver.port=1234`)
 
+### TLS Configuration for HTTP Endpoints
+
+To configure Transport Layer Security (TLS) for HTTP endpoints in edge module, the following configuration parameters can be used. These parameters allow you to specify key and keystore details necessary for setting up TLS.
+
+#### Configuration Parameters
+
+1. **`spring.ssl.bundle.jks.web-server.key.password`**
+- **Description**: Specifies the password for the private key in the keystore.
+- **Example**: `spring.ssl.bundle.jks.web-server.key.password=SecretPassword`
+
+2. **`spring.ssl.bundle.jks.web-server.key.alias`**
+- **Description**: Specifies the alias of the key within the keystore.
+- **Example**: `spring.ssl.bundle.jks.web-server.key.alias=localhost`
+
+3. **`spring.ssl.bundle.jks.web-server.keystore.location`**
+- **Description**: Specifies the location of the keystore file in the local file system.
+- **Example**: `spring.ssl.bundle.jks.web-server.keystore.location=/some/secure/path/test.keystore.bcfks`
+
+4. **`spring.ssl.bundle.jks.web-server.keystore.password`**
+- **Description**: Specifies the password for the keystore.
+- **Example**: `spring.ssl.bundle.jks.web-server.keystore.password=SecretPassword`
+
+5. **`spring.ssl.bundle.jks.web-server.keystore.type`**
+- **Description**: Specifies the type of the keystore. Common types include `JKS`, `PKCS12`, and `BCFKS`.
+- **Example**: `spring.ssl.bundle.jks.web-server.keystore.type=BCFKS`
+
+6. **`server.ssl.bundle`**
+- **Description**: Specifies which SSL bundle to use for configuring the server. This parameter links to the defined SSL bundle, for example, `web-server`.
+- **Example**: `server.ssl.bundle=web-server`
+
+7. **`server.port`**
+- **Description**: Specifies the port on which the server will listen for HTTPS requests.
+- **Example**: `server.port=8443`
+
+#### Example Configuration
+
+To enable TLS for the edge module using the above parameters, you need to provide them as the environment variables. Below is an example configuration:
+
+```properties
+spring.ssl.bundle.jks.web-server.key.password=SecretPassword
+spring.ssl.bundle.jks.web-server.key.alias=localhost
+spring.ssl.bundle.jks.web-server.keystore.location=classpath:test/test.keystore.bcfks
+spring.ssl.bundle.jks.web-server.keystore.password=SecretPassword
+spring.ssl.bundle.jks.web-server.keystore.type=BCFKS
+
+server.ssl.bundle=web-server
+server.port=8443
+```
+### TLS Configuration for Feign HTTP Clients
+
+To configure Transport Layer Security (TLS) for HTTP clients created using Feign annotations in the edge module, you can use the following configuration parameters. These parameters allow you to specify trust store details necessary for setting up TLS for Feign clients.
+
+#### Configuration Parameters
+
+1. **`folio.client.okapiUrl`**
+- **Description**: Specifies the base URL for the Okapi service.
+- **Example**: `folio.client.okapiUrl=https://okapi:443`
+
+2. **`folio.client.tls.enabled`**
+- **Description**: Enables or disables TLS for the Feign clients.
+- **Example**: `folio.client.tls.enabled=true`
+
+3. **`folio.client.tls.trustStorePath`**
+- **Description**: Specifies the location of the trust store file.
+- **Example**: `folio.client.tls.trustStorePath=classpath:/some/secure/path/test.truststore.bcfks`
+
+4. **`folio.client.tls.trustStorePassword`**
+- **Description**: Specifies the password for the trust store.
+- **Example**: `folio.client.tls.trustStorePassword="SecretPassword"`
+
+5. **`folio.client.tls.trustStoreType`**
+- **Description**: Specifies the type of the trust store. Common types include `JKS`, `PKCS12`, and `BCFKS`.
+- **Example**: `folio.client.tls.trustStoreType=bcfks`
+
+#### Note
+The `trustStorePath`, `trustStorePassword`, and `trustStoreType` parameters can be omitted if the server provides a public certificate.
+
+#### Example Configuration
+
+To enable TLS for Feign HTTP clients using the above parameters, you need to provide them as the environment variables. Below is an example configuration:
+
+```properties
+folio.client.okapiUrl=https://okapi:443
+folio.client.tls.enabled=true
+folio.client.tls.trustStorePath=classpath:test/test.truststore.bcfks
+folio.client.tls.trustStorePassword=SecretPassword
+folio.client.tls.trustStoreType=bcfks
+```
+
 ### Issue tracker
 See project [EDGEDCB](https://issues.folio.org/browse/EDGEDCB)
 at the [FOLIO issue tracker](https://dev.folio.org/guidelines/issue-tracker).

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <edge-common-spring.version>2.4.1</edge-common-spring.version>
+    <edge-common-spring.version>2.4.3</edge-common-spring.version>
     <edge-common.version>4.6.0</edge-common.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <wiremock-standalone.version>3.4.2</wiremock-standalone.version>
@@ -35,7 +35,10 @@
     <mockwebserver.version>4.11.0</mockwebserver.version>
 
     <edge-dcb.yaml.file>src/main/resources/swagger.api/edge-dcb.yaml</edge-dcb.yaml.file>
-    <sonar.exclusions>src/main/java/org/folio/ed/domain/**</sonar.exclusions>
+    <sonar.exclusions>src/main/java/org/folio/ed/domain/**, src/main/java/org/folio/ed/EdgeDcbApplication.java</sonar.exclusions>
+    <bc-fips.version>1.0.2.5</bc-fips.version>
+    <bcpkix-fips.version>1.0.7</bcpkix-fips.version>
+    <bctls-fips.version>1.0.19</bctls-fips.version>
   </properties>
 
   <dependencies>
@@ -49,6 +52,10 @@
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-starter-data-jpa</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk18on</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -60,6 +67,10 @@
         <exclusion>
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk18on</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -133,6 +144,21 @@
       <groupId>org.mapstruct</groupId>
       <artifactId>mapstruct</artifactId>
       <version>${mapstruct.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bc-fips</artifactId>
+      <version>${bc-fips.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-fips</artifactId>
+      <version>${bcpkix-fips.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bctls-fips</artifactId>
+      <version>${bctls-fips.version}</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/src/main/java/org/folio/ed/EdgeDcbApplication.java
+++ b/src/main/java/org/folio/ed/EdgeDcbApplication.java
@@ -1,5 +1,6 @@
 package org.folio.ed;
 
+import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -8,12 +9,19 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerA
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
+import java.security.Security;
+
+import static org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider.PROVIDER_NAME;
+
 @SpringBootApplication
 @EnableFeignClients
 @EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class, DataSourceTransactionManagerAutoConfiguration.class,
   HibernateJpaAutoConfiguration.class})
 public class EdgeDcbApplication {
   public static void main(String[] args) {
+    if (Security.getProvider(PROVIDER_NAME) == null) {
+      Security.addProvider(new BouncyCastleFipsProvider());
+    }
     SpringApplication.run(EdgeDcbApplication.class, args);
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,8 @@ server:
   port: 8081
 secure_store: ephemeral
 secure_store_props: src/main/resources/ephemeral.properties
-okapi_url: http://localhost:9130
+# okapi_url is deprecated. Please use folio.client.okapiUrl instead
+# okapi_url: http://localhost:9130
 spring:
   application:
     name: edge-dcb
@@ -40,6 +41,13 @@ folio:
     username: system-user
     password: ${SYSTEM_USER_PASSWORD} # This is not used but added to avoid DI errors from folio-spring-system-user
   environment: folio
+  client:
+    okapiUrl: https://localhost:9130
+    tls:
+      enabled: false
+#      trustStorePath: classpath:test/test.truststore.bcfks
+#      trustStorePassword: "SecretPassword"
+#      trustStoreType: bcfks
 logging:
   level:
     org:

--- a/src/test/java/org/folio/ed/controller/DcbEdgeRequestHandlingTest.java
+++ b/src/test/java/org/folio/ed/controller/DcbEdgeRequestHandlingTest.java
@@ -8,6 +8,7 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.folio.ed.domain.dto.TransactionStatus;
 import org.folio.edge.core.utils.ApiKeyUtils;
+import org.folio.edgecommonspring.client.EdgeFeignClientProperties;
 import org.folio.edgecommonspring.client.EnrichUrlClient;
 import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.spring.model.UserToken;
@@ -53,7 +54,7 @@ class DcbEdgeRequestHandlingTest {
   @Autowired
   private MockMvc mockMvc;
   @Autowired
-  private EnrichUrlClient enrichUrlClient;
+  private EdgeFeignClientProperties properties;
   @MockBean
   private SystemUserService systemUserService;
   private MockWebServer mockDcbServer;
@@ -62,7 +63,8 @@ class DcbEdgeRequestHandlingTest {
   void setUp() throws IOException {
     mockDcbServer = new MockWebServer();
     mockDcbServer.start();
-    ReflectionTestUtils.setField(enrichUrlClient, "okapiUrl", "http://localhost:" + mockDcbServer.getPort());
+    var url = "http://localhost:" + mockDcbServer.getPort();
+    ReflectionTestUtils.setField(properties, "okapiUrl", url);
   }
 
   @AfterEach

--- a/src/test/java/org/folio/ed/controller/DcbEdgeRequestHandlingTest.java
+++ b/src/test/java/org/folio/ed/controller/DcbEdgeRequestHandlingTest.java
@@ -9,7 +9,6 @@ import okhttp3.mockwebserver.MockWebServer;
 import org.folio.ed.domain.dto.TransactionStatus;
 import org.folio.edge.core.utils.ApiKeyUtils;
 import org.folio.edgecommonspring.client.EdgeFeignClientProperties;
-import org.folio.edgecommonspring.client.EnrichUrlClient;
 import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.spring.model.UserToken;
 import org.folio.spring.service.SystemUserService;
@@ -77,7 +76,7 @@ class DcbEdgeRequestHandlingTest {
     // Given
     var apiKey = ApiKeyUtils.generateApiKey(10, TENANT, USERNAME);
     var responseBody = ""; // Arbitrary string. We don't care about the actual content and an empty string is easy
-    setUpMockAuthnClient(TENANT, TOKEN);
+    setUpMockAuthnClient(TOKEN);
 
     // When we make a valid request to mod-dcb with the API key set
     mockDcbServer.enqueue(new MockResponse()
@@ -102,7 +101,7 @@ class DcbEdgeRequestHandlingTest {
     // Given
     var apiKey = ApiKeyUtils.generateApiKey(10, TENANT, USERNAME);
     var responseBody = ""; // Arbitrary string. We don't care about the actual content and an empty string is easy
-    setUpMockAuthnClient(TENANT, TOKEN);
+    setUpMockAuthnClient(TOKEN);
     // When we make a valid request to mod-dcb with the API key set
     mockDcbServer.enqueue(new MockResponse()
       .setResponseCode(201)
@@ -129,7 +128,7 @@ class DcbEdgeRequestHandlingTest {
     // Given
     var apiKey = ApiKeyUtils.generateApiKey(10, TENANT, USERNAME);
     var responseBody = ""; // Arbitrary string. We don't care about the actual content and an empty string is easy
-    setUpMockAuthnClient(TENANT, TOKEN);
+    setUpMockAuthnClient(TOKEN);
     var dcbTransaction = createDcbTransaction();
     dcbTransaction.setRole(null);
     // When we make a valid request to mod-dcb with the API key set
@@ -152,7 +151,7 @@ class DcbEdgeRequestHandlingTest {
     // Given
     var apiKey = ApiKeyUtils.generateApiKey(10, TENANT, USERNAME);
     var responseBody = ""; // Arbitrary string. We don't care about the actual content and an empty string is easy
-    setUpMockAuthnClient(TENANT, TOKEN);
+    setUpMockAuthnClient(TOKEN);
     var dcbTransaction = createDcbTransaction();
     dcbTransaction.getItem().setId("123");
     // When we make a valid request to mod-dcb with the API key set
@@ -174,7 +173,7 @@ class DcbEdgeRequestHandlingTest {
   void shouldThrowErrorForFeignException() throws Exception {
     // Given
     var apiKey = ApiKeyUtils.generateApiKey(10, TENANT, USERNAME);
-    setUpMockAuthnClient(TENANT, TOKEN);
+    setUpMockAuthnClient(TOKEN);
     var dcbTransaction = createDcbTransaction();
     // When we make a valid request to mod-dcb with the API key set
     org.folio.ed.domain.dto.Errors errors = org.folio.ed.domain.dto.Errors.builder()
@@ -207,7 +206,7 @@ class DcbEdgeRequestHandlingTest {
     var transactionId = "123";
     var apiKey = ApiKeyUtils.generateApiKey(10, tenant, username);
     var responseBody = ""; // Arbitrary string. We don't care about the actual content and an empty string is easy
-    setUpMockAuthnClient(tenant, token);
+    setUpMockAuthnClient(token);
 
     // When we make a valid request to mod-dcb with the API key set
     mockDcbServer.enqueue(new MockResponse()
@@ -238,7 +237,7 @@ class DcbEdgeRequestHandlingTest {
       token = "This is totally a real test token!";
     var apiKey = ApiKeyUtils.generateApiKey(10, tenant, username);
     var responseBody = ""; // Arbitrary string. We don't care about the actual content and an empty string is easy
-    setUpMockAuthnClient(tenant, token);
+    setUpMockAuthnClient(token);
 
     // When we make a valid request to mod-dcb with the API key set
     mockDcbServer.enqueue(new MockResponse()
@@ -270,7 +269,7 @@ class DcbEdgeRequestHandlingTest {
     var apiKey = ApiKeyUtils.generateApiKey(10, TENANT, USERNAME);
     var dcbResponseCode = HttpStatus.I_AM_A_TEAPOT.value(); // Arbitrary HTTP error status code
     var dcbResponseBody = "I'm a teapot, not an dcb transaction!";
-    setUpMockAuthnClient(TENANT, TOKEN);
+    setUpMockAuthnClient(TOKEN);
 
     // When mod-dcb responds with an error
     mockDcbServer.enqueue(new MockResponse()
@@ -286,7 +285,7 @@ class DcbEdgeRequestHandlingTest {
     assertThat(response.getContentAsString()).contains(dcbResponseBody);
   }
 
-  private void setUpMockAuthnClient(String tenant, String token) {
+  private void setUpMockAuthnClient(String token) {
     when(systemUserService.authSystemUser(any(), any(), any()))
       .thenReturn(new UserToken(token, Instant.now().plus(1, TimeUnit.HOURS.toChronoUnit())));
   }


### PR DESCRIPTION
The update covers adding a detailed guide on TLS configuration for HTTP endpoints and Feign HTTP clients to the README. A BouncyCastleFipsProvider has been added to the main EdgeDcbApplication class. The edge-common-spring library version has been updated and Bouncy Castle dependencies have been included in pom.xml.
