### PR TITLE
EDGEDCB-25: Spring Boot 3.2.6, edge-common-spring 2.4.4 fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.3</version>
+    <version>3.2.6</version>
     <relativePath />
   </parent>
 
@@ -23,7 +23,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <edge-common-spring.version>2.4.3</edge-common-spring.version>
+    <edge-common-spring.version>2.4.4</edge-common-spring.version>
     <edge-common.version>4.6.0</edge-common.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <wiremock-standalone.version>3.4.2</wiremock-standalone.version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGEDCB-25

Upgrade Spring Boot from 3.2.3 to 3.2.6.

Upgrade edge-common-spring from 2.4.3 to 2.4.4.

The Spring Boot upgrade indirectly upgrades spring-web:jar from 6.1.4 to 6.1.8 fixing two open redirect vulnerabilities in UriComponentsBuilder:

* https://www.cve.org/CVERecord?id=CVE-2024-22259
* https://www.cve.org/CVERecord?id=CVE-2024-22262

The edge-common-spring upgrade indirectly upgrades netty-codec-http from 4.1.107.Final to 4.1.110.Final fixing

* https://www.cve.org/CVERecord?id=CVE-2024-29025  – form POST out-of-memory

## Purpose
Fix security vulnerabilities.

## Approach
Upgrade patch version of dependencies.