### PR TITLE
bump up edge-common-spring to v2.4.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <edge-common-spring.version>2.4.4</edge-common-spring.version>
+    <edge-common-spring.version>2.4.5</edge-common-spring.version>
     <edge-common.version>4.6.0</edge-common.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <wiremock-standalone.version>3.4.2</wiremock-standalone.version>
@@ -33,7 +33,6 @@
     <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
     <folio-spring-support.version>8.1.0</folio-spring-support.version>
     <mockwebserver.version>4.11.0</mockwebserver.version>
-    <folio-tls-utils.version>1.5.0</folio-tls-utils.version>
 
     <edge-dcb.yaml.file>src/main/resources/swagger.api/edge-dcb.yaml</edge-dcb.yaml.file>
     <sonar.exclusions>src/main/java/org/folio/ed/domain/**, src/main/java/org/folio/ed/EdgeDcbApplication.java</sonar.exclusions>
@@ -142,11 +141,6 @@
       <groupId>org.mapstruct</groupId>
       <artifactId>mapstruct</artifactId>
       <version>${mapstruct.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.folio</groupId>
-      <artifactId>folio-tls-utils</artifactId>
-      <version>${folio-tls-utils.version}</version>
     </dependency>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
bump up edge-common-spring to v2.4.5: AwsParamStore to support FIPS-approved crypto modules
