### PR TITLE
EDGEDCB-33: Quesnelia: Spring Boot 3.2.12 fixing tomcat HTTP/2 DoS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.6</version>
+    <version>3.2.12</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGEDCB-33

## Purpose
Fix tomcat HTTP/2 DoS security vulnerability:

https://nvd.nist.gov/vuln/detail/CVE-2024-34750

## Approach
Upgrade Spring boot from 3.2.6 to 3.2.12.

This indirectly upgrades tomcat-embed-core from 10.1.19 to 10.1.31 with the security fix.

## Pre-Merge Checklist:
 
Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [x] There are no breaking changes in this PR.
   - [x] Check logging