### PR TITLE
EDGEDCB-36: Quesnelia: Enable TLS hostname verification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,15 +23,15 @@
 
   <properties>
     <java.version>17</java.version>
-    <edge-common-spring.version>2.4.5</edge-common-spring.version>
-    <edge-common.version>4.6.0</edge-common.version>
+    <edge-common-spring.version>2.4.6</edge-common-spring.version>
+    <edge-common.version>4.7.2</edge-common.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <wiremock-standalone.version>3.4.2</wiremock-standalone.version>
     <awaitility.version>4.2.0</awaitility.version>
     <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
     <openapi-generator-maven-plugin.version>7.3.0</openapi-generator-maven-plugin.version>
     <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
-    <folio-spring-support.version>8.1.0</folio-spring-support.version>
+    <folio-spring-support.version>8.1.2</folio-spring-support.version>
     <mockwebserver.version>4.11.0</mockwebserver.version>
 
     <edge-dcb.yaml.file>src/main/resources/swagger.api/edge-dcb.yaml</edge-dcb.yaml.file>


### PR DESCRIPTION


<!--
   If you have a relevant JIRA issue number, please put it in the issue title.
   Example: MODQM-3 - Implement GET records-editor/marc-records/{id} endpoint

   TL;DR
     - https://www.youtube.com/watch?v=5aHmO_S8FQ4
     - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
     - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
 -->

## Purpose
Enable TLS hostname verification.

## Approach
Upgrade dependencies:

https://folio-org.atlassian.net/browse/EDGEDCB-36

Enable TLS hostname verification by upgrading dependencies:

Upgrade edge-common-spring from 2.4.5 to 2.4.6:

* https://github.com/folio-org/edge-common-spring/releases/tag/v2.4.6

Upgrade edge-common from 4.6.0 to 4.7.2:

* https://github.com/folio-org/edge-common/releases/tag/v4.7.2

Upgrade folio-spring-support from 8.2.0 to 8.2.2:

* https://github.com/folio-org/folio-spring-support/releases/tag/v8.1.1
* https://github.com/folio-org/folio-spring-support/releases/tag/v8.1.2

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [x] There are no breaking changes in this PR.
   - [x] Check logging